### PR TITLE
Add PDF export to simulator

### DIFF
--- a/simulator.ts
+++ b/simulator.ts
@@ -35,24 +35,22 @@
  function simulate(isSentient: boolean): SimulationState[] {
    const log: SimulationState[] = []
  
-   let state: SimulationState = {
-     minute: 0,
-     externalTemp: 78,
-     hvacOn: false,
-     energyUsed_kWh: 0,
-     rooms: Object.fromEntries(
-       ROOMS.map((room) => [
-         room,
-         {
-           temp: 72,
-           occupied: false,
-           targetTemp: 72,
-           comfortViolations: 0,
-           runtimeMinutes: 0,
-         },
-       ])
-     ) as Record<Room, RoomState>,
-   }
+  let state: SimulationState = {
+    minute: 0,
+    externalTemp: 78,
+    hvacOn: false,
+    energyUsed_kWh: 0,
+    rooms: ROOMS.reduce((acc, room) => {
+      acc[room] = {
+        temp: 72,
+        occupied: false,
+        targetTemp: 72,
+        comfortViolations: 0,
+        runtimeMinutes: 0,
+      }
+      return acc
+    }, {} as Record<Room, RoomState>),
+  }
  
    for (let i = 0; i < TOTAL_MINUTES; i++) {
      state.minute = i

--- a/src/visualizer/ControlPanel.tsx
+++ b/src/visualizer/ControlPanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { legacyData, sentientData } from '../../simulator'
 import { saveAs } from 'file-saver'
+import { exportSimulationSummaryPDF } from './exportPdf'
 
 const ROOMS = ['TherapyA', 'TherapyB', 'Waiting', 'Admin'] as const
 
@@ -54,7 +55,7 @@ export default function ControlPanel() {
   const comfortDelta = totalComfortLegacy - totalComfortSentient
 
   return (
-    <div className="p-4 border rounded-md shadow-sm bg-white mb-8">
+    <div data-sim-summary className="p-4 border rounded-md shadow-sm bg-white mb-8">
       <h2 className="text-xl font-bold mb-2">Simulation Summary</h2>
       <ul className="space-y-1 text-sm">
         <li><strong>Total Energy Saved:</strong> {energySaved.toFixed(2)} kWh</li>
@@ -74,6 +75,12 @@ export default function ControlPanel() {
           className="px-3 py-1 border rounded bg-green-100 hover:bg-green-200"
         >
           Export SentientZone CSV
+        </button>
+        <button
+          onClick={exportSimulationSummaryPDF}
+          className="px-3 py-1 border rounded bg-blue-100 hover:bg-blue-200"
+        >
+          Download PDF Summary
         </button>
       </div>
     </div>

--- a/src/visualizer/exportPdf.ts
+++ b/src/visualizer/exportPdf.ts
@@ -1,0 +1,31 @@
+import jsPDF from 'jspdf'
+import html2canvas from 'html2canvas'
+
+export async function exportSimulationSummaryPDF() {
+  const pdf = new jsPDF('p', 'pt', 'a4')
+  const margin = 40
+  let y = margin
+
+  const title = 'SentientZone Simulation Summary – 30 Day Case Study'
+  pdf.setFontSize(18)
+  pdf.text(title, margin, y)
+  y += 30
+
+  const summaryElem = document.querySelector('[data-sim-summary]')
+  if (summaryElem) {
+    const canvas = await html2canvas(summaryElem as HTMLElement)
+    const imgData = canvas.toDataURL('image/png')
+    pdf.addImage(imgData, 'PNG', margin, y, 520, 140)
+    y += 150
+  }
+
+  const charts = document.querySelectorAll('canvas')
+  for (let i = 0; i < charts.length && y < 750; i++) {
+    const canvas = charts[i] as HTMLCanvasElement
+    const img = canvas.toDataURL('image/png')
+    pdf.addImage(img, 'PNG', margin, y, 520, 120)
+    y += 130
+  }
+
+  pdf.save('sentientzone_sim_summary.pdf')
+}


### PR DESCRIPTION
## Summary
- add exportPdf helper and integrate download button
- mark summary container for pdf capture
- rework simulator state init to avoid `Object.fromEntries`

## Testing
- `tsc simulator.ts`


------
https://chatgpt.com/codex/tasks/task_e_685ecfc2c808832db02768a5ae181383